### PR TITLE
Add BodyGen-compatible environment

### DIFF
--- a/envs/ig_gym_wrapper.py
+++ b/envs/ig_gym_wrapper.py
@@ -1,0 +1,102 @@
+"""BodyGen compatible environment wrapper."""
+
+from typing import Any, ClassVar, Dict, Optional
+
+import gymnasium as gym
+import numpy as np
+
+from transform2act.envs.transform2act_ik_env import Transform2ActIKEnv
+
+
+class IGEnv(Transform2ActIKEnv, gym.Env):
+    """Gymnasium wrapper around :class:`Transform2ActIKEnv` used by BodyGen."""
+
+    metadata: ClassVar[dict[str, Any]] = {
+        "render_modes": ["human", "rgb_array"],
+        "render_fps": 30,
+    }
+
+    def __init__(
+        self,
+        cfg: Dict[str, Any],
+        random_seed: int = 0,
+        init_xml: Optional[str] = None,
+    ) -> None:
+        """Initialize the environment.
+
+        Parameters
+        ----------
+        cfg:
+            Configuration dictionary understood by :class:`Transform2ActIKEnv`.
+        random_seed:
+            Seed for reproducibility.
+        init_xml:
+            Optional XML string used by the base class (ignored for IK task).
+
+        """
+        super().__init__(cfg, random_seed=random_seed, init_xml=init_xml)
+
+        # Expose additional dimensions required by BodyGen
+        self.sim_obs_dim = self._get_sim_obs().shape[-1]
+        self.attr_fixed_dim = self._get_attr_fixed().shape[-1]
+        self.attr_design_dim = self._get_attr_design().shape[-1]
+        self.control_action_dim = self.current_links
+        self.skel_num_action = 3
+
+    def _map_stage(self, stage: str) -> str:
+        """Convert internal stage name to BodyGen's stage name."""
+        mapping = {
+            "skel_trans": "skeleton_transform",
+            "attr_trans": "attribute_transform",
+            "execution": "execution",
+        }
+        return mapping.get(stage, stage)
+
+    # ------------------------------------------------------------------
+    # Gymnasium API
+    # ------------------------------------------------------------------
+    def reset(
+        self,
+        *,
+        seed: Optional[int] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> tuple[np.ndarray, Dict[str, Any]]:
+        """Reset the environment and return the initial observation."""
+        if seed is not None:
+            np.random.seed(seed)
+        obs = self.reset_model()
+        info = {
+            "use_transform_action": self.use_transform_action,
+            "stage": self._map_stage(self.stage),
+        }
+        return obs, info
+
+    def step(self, action: np.ndarray) -> tuple[np.ndarray, float, bool, bool, Dict[str, Any]]:
+        """Take a step using an action from the agent."""
+        obs, reward, done, info = super().step(action)
+        info.update(
+            {
+                "use_transform_action": self.use_transform_action,
+                "stage": self._map_stage(self.stage),
+            }
+        )
+        return obs, reward, done, False, info
+
+    # ------------------------------------------------------------------
+    # Convenience methods for BodyGen compatibility
+    # ------------------------------------------------------------------
+    def if_use_transform_action(self) -> int:
+        """Return the index of the current stage used by BodyGen agents."""
+        return ["skel_trans", "attr_trans", "execution"].index(self.stage)
+
+    def get_attr_fixed(self) -> np.ndarray:
+        """Return fixed attributes for each link."""
+        return self._get_attr_fixed().reshape(self.current_links + 1, -1)
+
+    def get_sim_obs(self) -> np.ndarray:
+        """Return simulation observations for each link."""
+        return self._get_sim_obs().reshape(self.current_links, -1)
+
+    def get_attr_design(self) -> np.ndarray:
+        """Return design attributes for each link."""
+        return self._get_attr_design().reshape(self.current_links, -1)

--- a/setup_path.py
+++ b/setup_path.py
@@ -1,4 +1,5 @@
 """Setup Python path to include co_design_task.
+
 Import this at the beginning of scripts to ensure co_design_task is available.
 """
 


### PR DESCRIPTION
## Summary
- create `IGEnv` for BodyGen support
- expose new `--env` flag in `train_rl.py`
- handle IGEnv configuration in the training script
- ignore style checks for new file
- minor docstring fix in setup_path
- refine IGEnv docstrings and remove lint ignores
- map stage names to BodyGen style and include them in `info`

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686eda184e80832e87477a587559935a